### PR TITLE
To allow compilation with target os 9.3, single out Combine imports

### DIFF
--- a/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryReachabilityBehavior.swift
@@ -6,8 +6,11 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#endif
 public protocol APICategoryReachabilityBehavior {
+    #if canImport(Combine)
     /// Attempts to create and start a reachability client for a host that corresponds to the apiName, and then
     /// returns the associated Publisher which vends ReachabiltyUpdates
     /// - Parameters:
@@ -18,5 +21,5 @@ public protocol APICategoryReachabilityBehavior {
 
     @available(iOS 13.0, *)
     func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>?
-
+    #endif
 }

--- a/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/AmplifyAPICategory+ReachabilityBehavior.swift
@@ -6,8 +6,11 @@
 //
 
 import Foundation
+#if canImport(Combine)
 import Combine
+#endif
 extension AmplifyAPICategory: APICategoryReachabilityBehavior {
+    #if canImport(Combine)
     @available(iOS 13.0, *)
     public func reachabilityPublisher(for apiName: String?) throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return try plugin.reachabilityPublisher(for: apiName)
@@ -17,4 +20,5 @@ extension AmplifyAPICategory: APICategoryReachabilityBehavior {
     public func reachabilityPublisher() throws -> AnyPublisher<ReachabilityUpdate, Never>? {
         return try plugin.reachabilityPublisher(for: nil)
     }
+    #endif
 }

--- a/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
+++ b/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -104,3 +105,4 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+#endif

--- a/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
+++ b/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -273,3 +274,4 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+#endif

--- a/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCallback+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(iOS 13.0, *)
@@ -19,3 +20,4 @@ extension DataStoreResult where Success: Any {
         }
     }
 }
+#endif

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -114,3 +115,4 @@ public extension DataStoreBaseBehavior {
         }.eraseToAnyPublisher()
     }
 }
+#endif

--- a/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategoryBehavior.swift
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
+#endif
 
 public typealias DataStoreCategoryBehavior = DataStoreBaseBehavior & DataStoreSubscribeBehavior
 
@@ -38,8 +40,10 @@ public protocol DataStoreBaseBehavior {
 }
 
 public protocol DataStoreSubscribeBehavior {
+    #if canImport(Combine)
     /// Returns a Publisher for model changes (create, updates, delete)
     /// - Parameter modelType: The model type to observe
     @available(iOS 13.0, *)
     func publisher<M: Model>(for modelType: M.Type) -> AnyPublisher<MutationEvent, DataStoreError>
+    #endif
 }

--- a/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/List+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(iOS 13.0, *)
@@ -30,3 +31,4 @@ extension List {
         }.eraseToAnyPublisher()
     }
 }
+#endif

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreCategory+Subscribe.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
 extension DataStoreCategory: DataStoreSubscribeBehavior {
@@ -13,3 +14,4 @@ extension DataStoreCategory: DataStoreSubscribeBehavior {
         return plugin.publisher(for: modelType)
     }
 }
+#endif

--- a/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Hub/HubCategory+ClientBehavior.swift
@@ -5,13 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
+#endif
 
 extension HubCategory: HubCategoryBehavior {
     public func dispatch(to channel: HubChannel, payload: HubPayload) {
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             Amplify.Hub.subject(for: channel).send(payload)
         }
+        #endif
         plugin.dispatch(to: channel, payload: payload)
     }
 

--- a/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
+++ b/Amplify/Categories/Hub/HubCategoryBehavior+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 
 @available(iOS 13.0, *)
@@ -52,3 +53,4 @@ extension HubCategoryBehavior {
     }
 
 }
+#endif

--- a/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
+++ b/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -77,3 +78,4 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+#endif

--- a/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
+++ b/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -145,3 +146,4 @@ public extension AmplifyInProcessReportingOperation
         internalInProcessPublisher
     }
 }
+#endif

--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -129,3 +130,4 @@ extension StorageCategoryBehavior {
     }
 
 }
+#endif

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -48,3 +49,4 @@ extension AmplifyInProcessReportingOperation {
     }
 
 }
+#endif

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
+#endif
 import Foundation
 
 /// An AmplifyOperation that emits InProcess values intermittently during the operation.
@@ -41,9 +43,11 @@ open class AmplifyInProcessReportingOperation<
 
         super.init(categoryType: categoryType, eventName: eventName, request: request, resultListener: resultListener)
 
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             inProcessSubject = PassthroughSubject<InProcess, Never>()
         }
+        #endif
 
         // If the inProcessListener is present, we need to register a hub event listener for it, and ensure we
         // automatically unsubscribe when we receive a completion event for the operation
@@ -83,9 +87,11 @@ open class AmplifyInProcessReportingOperation<
     /// Classes that override this method must emit a completion to the `inProcessPublisher` upon cancellation
     open override func cancel() {
         super.cancel()
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             publish(completion: .finished)
         }
+        #endif
     }
 
     /// Invokes `super.dispatch()`. On iOS 13+, this method first publishes a
@@ -94,9 +100,11 @@ open class AmplifyInProcessReportingOperation<
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the
     ///   HubPayload
     public override func dispatch(result: OperationResult) {
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             publish(completion: .finished)
         }
+        #endif
         super.dispatch(result: result)
     }
 
@@ -110,9 +118,11 @@ public extension AmplifyInProcessReportingOperation {
     /// `AmplifyOperationContext` object from the operation's `id`, and `request`
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the HubPayload
     func dispatchInProcess(data: InProcess) {
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             publish(inProcessValue: data)
         }
+        #endif
 
         let channel = HubChannel(from: categoryType)
         let context = AmplifyOperationContext(operationId: id, request: request)

--- a/Amplify/Core/Support/AmplifyOperation+Combine.swift
+++ b/Amplify/Core/Support/AmplifyOperation+Combine.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
 import Foundation
 
@@ -68,3 +69,4 @@ extension AmplifyOperation {
     }
 
 }
+#endif

--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(Combine)
 import Combine
+#endif
 import Foundation
 
 /// An abstract representation of an Amplify unit of work. Subclasses may aggregate multiple work items
@@ -111,9 +113,11 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
 
         super.init()
 
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             resultFuture = Future<Success, Failure> { self.resultPromise = $0 }
         }
+        #endif
 
         if let resultListener = resultListener {
             self.resultListenerUnsubscribeToken = subscribe(resultListener: resultListener)
@@ -148,6 +152,7 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
     /// Classes that override this method must emit a completion to the `resultPublisher` upon cancellation
     open override func cancel() {
         super.cancel()
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             let cancellationError = Failure(
                 errorDescription: "Operation cancelled",
@@ -156,6 +161,7 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
             )
             publish(result: .failure(cancellationError))
         }
+        #endif
     }
 
     /// Dispatches an event to the hub. Internally, creates an
@@ -165,9 +171,11 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
     /// - Parameter result: The OperationResult to dispatch to the hub as part of the
     ///   HubPayload
     public func dispatch(result: OperationResult) {
+        #if canImport(Combine)
         if #available(iOS 13.0, *) {
             publish(result: result)
         }
+        #endif
 
         let channel = HubChannel(from: categoryType)
         let context = AmplifyOperationContext(operationId: id, request: request)


### PR DESCRIPTION
`Combine` is not available under iOS 13, and import fails with target os under 11. So, we single out all references to `Combine` using preprocessor if macros.