### PR TITLE
Force the provider login window to show in fullscreen

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Dependency/AuthenticationProviderAdapter+SignIn.swift
@@ -138,7 +138,7 @@ extension AuthenticationProviderAdapter {
                                               signOutURIQueryParameters: request.options.signOutQueryParameters)
 
         // Create a navigation controller with an empty UIViewController.
-        let navController = UINavigationController(rootViewController: UIViewController())
+        let navController = FullScreenNavigationUIController(rootViewController: UIViewController())
         navController.isNavigationBarHidden = true
         navController.modalPresentationStyle = .overCurrentContext
 
@@ -226,4 +226,13 @@ extension AuthenticationProviderAdapter {
         return authError
     }
 
+}
+
+private class FullScreenNavigationUIController: UINavigationController {
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        viewControllerToPresent.modalPresentationStyle = .fullScreen
+
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
 }


### PR DESCRIPTION
On some device, the sign-in popup does not take the whole screen. When clicking outside, the view is hidden without being considered dismissed, so the app stays stuck in a transitional state.

The easy solution that was picked is to make sure that popup is always shown in fullscreen.

Note that this solution only works for iOS 11 and over, as a different technique is used for the other versions.